### PR TITLE
Fix positional encoding docstring

### DIFF
--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -23,7 +23,10 @@ class PositionalEncoding(nn.Module):
 
     def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
         """
-        Adds positional embeddings to the input.
+        Return positional embeddings for the input sequence length. The input is
+        not modified; instead, a tensor containing the learned positional
+        embeddings is returned for the caller to combine with the input as
+        needed.
 
         Args:
             input_ids (torch.Tensor): Input token IDs to determine sequence length


### PR DESCRIPTION
## Summary
- update positional encoding docstring to clarify it returns embeddings

## Testing
- `python -m py_compile src/utils/helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_68436e2ae4ec83229be1258bd54d69f8