### PR TITLE
Add GatingNetwork test

### DIFF
--- a/tests/test_gating_network.py
+++ b/tests/test_gating_network.py
@@ -1,0 +1,16 @@
+import torch
+from src.models.modules import GatingNetwork
+
+def test_gating_network_softmax_sum():
+    batch_size = 2
+    seq_len = 4
+    d_model = 8
+    gate_hidden = 4
+    num_outputs = 3
+
+    gating = GatingNetwork(d_model, gate_hidden, num_outputs, activation='relu')
+    x = torch.randn(batch_size, seq_len, d_model)
+    weights = gating(x)
+    assert weights.shape == (batch_size, seq_len, num_outputs)
+    sums = weights.sum(dim=-1)
+    assert torch.allclose(sums, torch.ones_like(sums), atol=1e-5)


### PR DESCRIPTION
## Summary
- add `tests/test_gating_network.py` that checks gate weights sum to one

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68436e304c108322b9fc78f283ca3a1b