### PR TITLE
Fix variable name in palindrome dataloader

### DIFF
--- a/src/data/dataloader_char_palindrome.py
+++ b/src/data/dataloader_char_palindrome.py
@@ -45,7 +45,7 @@ def generate_palindrome_sequence(
              payload = [random.choice(PAYLOAD_ALPHABET) for _ in range(payload_len)]
 
     num_initial_dist = random.randint(0, max_init_dist)
-    num_trailing_dist = random.randint(0, max_trail_dist)
+    num_trailing_dist = random.randint(0, max_trailing_dist)
 
     # Ensure total length doesn't exceed max_seq_len - 1 (for CLS)
     total_non_distractor = 1 + payload_len + 1 # MarkerA + payload + MarkerB


### PR DESCRIPTION
## Summary
- fix typo in `generate_palindrome_sequence`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6843727ebb5c8322929e63c6571335c9